### PR TITLE
changed transition end to keyup

### DIFF
--- a/solutions/beatBoxJS(Solution)/utils.js
+++ b/solutions/beatBoxJS(Solution)/utils.js
@@ -23,7 +23,7 @@ class Button {
     }
 
     createTransitionEndListener = () => {
-        this.element.addEventListener("transitionend", ()=>{
+        this.element.addEventListener("keyup", ()=>{
             this.deselect();
         })
     }


### PR DESCRIPTION
I have changed the transition end event listener to keyup event listener because if you press a key for a long time transition event lister will get confused and background + box-shadow will not get removed